### PR TITLE
support biome v2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style=space
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+insert_final_newline=true
+trim_trailing_whitespace=true
+max_line_length = 80

--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
-# biome-config
+# `@kibertoad/biome-config`
+
 ToadStack config for Biome
 
 ## Getting started
 
-You can use the following biome.json configuration:
+1. Install required dependencies
 
-```json
-{
-	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
-	"extends": ["./node_modules/@kibertoad/biome-config/configs/biome-package.json"]
-}
-```
+   ```sh
+   npm install @biomejs/biome @kibertoad/biome-config
+   ```
+
+2. Create a `biome.json` configuration file
+
+   ```json
+   {
+     "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+     "extends": ["./node_modules/@kibertoad/biome-config/configs/biome-package.json"]
+   }
+   ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ ToadStack config for Biome
 1. Install required dependencies
 
    ```sh
-   npm install @biomejs/biome @kibertoad/biome-config
+   npm install --save-dev @biomejs/biome @kibertoad/biome-config
    ```
 
 2. Create a `biome.json` configuration file

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "extends": ["./configs/biome-package.json"],
+  "files": {
+    "includes": ["configs/*"]
+  }
+}

--- a/configs/biome-package.json
+++ b/configs/biome-package.json
@@ -1,147 +1,150 @@
 {
-	"$schema": "../node_modules/@biomejs/biome/configuration_schema.json",
-	"organizeImports": {
-		"enabled": true
-	},
-	"json": {
-		"formatter": {
-			"enabled": true,
-			"trailingCommas": "none",
-			"lineWidth": 100,
-			"indentStyle": "space",
-			"indentWidth": 2,
-			"lineEnding": "lf"
-		}
-	},
-	"javascript": {
-		"globals": ["vitest"],
-		"formatter": {
-			"enabled": true,
-			"arrowParentheses": "always",
-			"bracketSpacing": true,
-			"indentWidth": 2,
-			"indentStyle": "space",
-			"semicolons": "asNeeded",
-			"lineWidth": 100,
-			"quoteStyle": "single",
-			"trailingCommas": "all"
-		}
-	},
-	"files": {
-		"include": [
-			"./test/**/*.ts",
-			"./src/**/*.ts",
-			"./lib/**/*.ts",
-			"./index.ts",
-			"./scripts/**/*.ts",
-			"./biome.json",
-			"./package.json"
-		],
-		"ignore": ["./dist", "./coverage", "./node_modules"]
-	},
-	"formatter": {
-		"enabled": true,
-		"lineEnding": "lf",
-		"indentStyle": "space",
-		"indentWidth": 2
-	},
-	"linter": {
-		"rules": {
-			"performance": {
-				"noAccumulatingSpread": "error",
-				"noBarrelFile": "error",
-				"noDelete": "error",
-				"noReExportAll": "error"
-			},
-			"style": {
-				"noNonNullAssertion": "off",
-				"noDefaultExport": "error",
-				"noParameterAssign": "error",
-				"useTemplate": "error",
-				"useShorthandAssign": "error",
-				"useShorthandFunctionType": "error",
-				"noVar": "error",
-				"noUselessElse": "error",
-				"noUnusedTemplateLiteral": "off",
-				"useConst": "error",
-				"useExportType": "error",
-				"useNodejsImportProtocol": "error",
-				"useForOf": "error",
-				"useImportType": "error",
-				"useExponentiationOperator": "off"
-			},
-			"correctness": {
-				"noConstAssign": "error",
-				"noConstructorReturn": "error",
-				"noGlobalObjectCalls": "error",
-				"noInnerDeclarations": "error",
-				"noInvalidConstructorSuper": "error",
-				"noInvalidNewBuiltin": "error",
-				"noSelfAssign": "error",
-				"noSetterReturn": "error",
-				"noUnreachable": "error",
-				"useYield": "error",
-				"useValidForDirection": "error",
-				"noUnusedVariables": "error",
-				"noUnusedImports": "error",
-				"noUnusedPrivateClassMembers": "error",
-				"noUnreachableSuper": "error",
-				"noUndeclaredVariables": "error"
-			},
-			"suspicious": {
-				"noGlobalIsNan": "off",
-				"noAssignInExpressions": "error",
-				"noCatchAssign": "error",
-				"noClassAssign": "error",
-				"noConsoleLog": "error",
-				"noDuplicateCase": "error",
-				"noDuplicateClassMembers": "error",
-				"noEmptyBlockStatements": "off",
-				"useValidTypeof": "error",
-				"useIsArray": "error",
-				"useGetterReturn": "error",
-				"useAwait": "error",
-				"noSkippedTests": "off",
-				"noShadowRestrictedNames": "error",
-				"noRedeclare": "error",
-				"noDuplicateParameters": "error",
-				"noDuplicateObjectKeys": "error",
-				"noPrototypeBuiltins": "error",
-				"noMisleadingInstantiator": "error",
-				"noExplicitAny": "error",
-				"noFocusedTests": "error",
-				"noGlobalAssign": "error",
-				"noFunctionAssign": "error"
-			},
-			"complexity": {
-				"noForEach": "error",
-				"useOptionalChain": "error",
-				"noEmptyTypeParameters": "off",
-				"noExcessiveCognitiveComplexity": {
-					"level": "error",
-					"options": {
-						"maxAllowedComplexity": 15
-					}
-				},
-				"noExtraBooleanCast": "error",
-				"noBannedTypes": "off"
-			}
-		}
-	},
-	"overrides": [
-		{
-			"include": [
-				"./lib/**/*.spec.ts",
-				"./src/**/*.spec.ts",
-				"./test/**/*.spec.ts"
-			],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"noExplicitAny": "off"
-					}
-				}
-			}
-		}
-	]
+  "$schema": "../node_modules/@biomejs/biome/configuration_schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "json": {
+    "formatter": {
+      "enabled": true,
+      "trailingCommas": "none",
+      "lineWidth": 100,
+      "indentStyle": "space",
+      "indentWidth": 2,
+      "lineEnding": "lf"
+    }
+  },
+  "javascript": {
+    "globals": ["vitest"],
+    "formatter": {
+      "enabled": true,
+      "arrowParentheses": "always",
+      "bracketSpacing": true,
+      "indentWidth": 2,
+      "indentStyle": "space",
+      "semicolons": "asNeeded",
+      "lineWidth": 100,
+      "quoteStyle": "single",
+      "trailingCommas": "all"
+    }
+  },
+  "files": {
+    "includes": [
+      "test/**/*.ts",
+      "src/**/*.ts",
+      "lib/**/*.ts",
+      "index.ts",
+      "scripts/**/*.ts",
+      "biome.json",
+      "package.json",
+      "!dist",
+      "!coverage",
+      "!node_modules"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "lineEnding": "lf",
+    "indentStyle": "space",
+    "indentWidth": 2
+  },
+  "linter": {
+    "rules": {
+      "performance": {
+        "noAccumulatingSpread": "error",
+        "noBarrelFile": "error",
+        "noDelete": "error",
+        "noReExportAll": "error"
+      },
+      "style": {
+        "noNonNullAssertion": "off",
+        "noDefaultExport": "error",
+        "noParameterAssign": "error",
+        "useTemplate": "error",
+        "useShorthandAssign": "error",
+        "useShorthandFunctionType": "error",
+        "noUselessElse": "error",
+        "noUnusedTemplateLiteral": "off",
+        "useConst": "error",
+        "useExportType": "error",
+        "useNodejsImportProtocol": "error",
+        "useForOf": "error",
+        "useImportType": "error",
+        "useExponentiationOperator": "off",
+        "useAsConstAssertion": "error",
+        "useDefaultParameterLast": "error",
+        "useEnumInitializers": "error",
+        "useSelfClosingElements": "error",
+        "useSingleVarDeclarator": "error",
+        "useNumberNamespace": "error",
+        "noInferrableTypes": "error"
+      },
+      "correctness": {
+        "noConstAssign": "error",
+        "noConstructorReturn": "error",
+        "noGlobalObjectCalls": "error",
+        "noInnerDeclarations": "error",
+        "noInvalidConstructorSuper": "error",
+        "noSelfAssign": "error",
+        "noSetterReturn": "error",
+        "noUnreachable": "error",
+        "useYield": "error",
+        "useValidForDirection": "error",
+        "noUnusedVariables": "error",
+        "noUnusedImports": "error",
+        "noUnusedPrivateClassMembers": "error",
+        "noUnreachableSuper": "error",
+        "noUndeclaredVariables": "error",
+        "noInvalidBuiltinInstantiation": "error",
+        "useValidTypeof": "error"
+      },
+      "suspicious": {
+        "noGlobalIsNan": "off",
+        "noAssignInExpressions": "error",
+        "noCatchAssign": "error",
+        "noClassAssign": "error",
+        "noDuplicateCase": "error",
+        "noDuplicateClassMembers": "error",
+        "noEmptyBlockStatements": "off",
+        "useIsArray": "error",
+        "useGetterReturn": "error",
+        "useAwait": "error",
+        "noSkippedTests": "off",
+        "noShadowRestrictedNames": "error",
+        "noRedeclare": "error",
+        "noDuplicateParameters": "error",
+        "noDuplicateObjectKeys": "error",
+        "noPrototypeBuiltins": "error",
+        "noMisleadingInstantiator": "error",
+        "noExplicitAny": "error",
+        "noFocusedTests": "error",
+        "noGlobalAssign": "error",
+        "noFunctionAssign": "error",
+        "noVar": "error",
+        "noConsole": { "level": "error", "options": { "allow": ["log"] } }
+      },
+      "complexity": {
+        "noForEach": "error",
+        "useOptionalChain": "error",
+        "noEmptyTypeParameters": "off",
+        "noExcessiveCognitiveComplexity": {
+          "level": "error",
+          "options": {
+            "maxAllowedComplexity": 15
+          }
+        },
+        "noExtraBooleanCast": "error",
+        "noBannedTypes": "off"
+      }
+    }
+  },
+  "overrides": [
+    {
+      "includes": ["lib/**/*.spec.ts", "src/**/*.spec.ts", "test/**/*.spec.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/kibertoad/biome-config",
   "files": [
-    "configs"
+    "configs/biome-package.json"
   ],
   "exports": {
     "./*": [

--- a/package.json
+++ b/package.json
@@ -1,22 +1,30 @@
 {
-	"name": "@kibertoad/biome-config",
-	"version": "1.2.1",
-	"description": "",
-	"type": "module",
-	"scripts": {
-		"format": "biome check --write ."
-	},
-	"repository": {
-		"type": "git",
-		"url": "https://github.com/kibertoad/biome-config.git"
-	},
-	"files": ["configs/biome-package.json", "LICENSE", "README.md"],
-	"homepage": "https://github.com/kibertoad/biome-config",
-	"exports": {
-		"./*": ["./configs/*.json"]
-	},
-	"private": false,
-	"devDependencies": {
-		"@biomejs/biome": "^1.8.2"
-	}
+  "name": "@kibertoad/biome-config",
+  "version": "1.2.1",
+  "description": "",
+  "type": "module",
+  "private": false,
+  "scripts": {
+    "format": "biome check .",
+    "format:fix": "biome check . --write"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kibertoad/biome-config.git"
+  },
+  "homepage": "https://github.com/kibertoad/biome-config",
+  "files": [
+    "configs"
+  ],
+  "exports": {
+    "./*": [
+      "./configs/*.json"
+    ]
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.0.5"
+  },
+  "peerDependencies": {
+    "@biomejs/biome": "^2.0.5"
+  }
 }


### PR DESCRIPTION
- Coming from https://github.com/turkerdev/fastify-type-provider-zod/pull/179 😅

This PR adds supports for biome v2.

Migration has been converted using the CLI command from the [official migration guide](https://biomejs.dev/guides/upgrade-to-biome-v2/).

```sh
npx @biomejs/biome migrate --write
```